### PR TITLE
Introduces Docker testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+.git/
+*.pyc
+**/__pycache__
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Docker image for installing dependencies on Linux and running tests.
+# Build with:
+# docker build --tag=gerardpuig/ubuntu-cleaner --file=dockerfiles/Dockerfile-linux .
+# Run with:
+# docker run -it --rm gerardpuig/ubuntu-cleaner make test
+# Or for interactive shell:
+# docker run -it --rm gerardpuig/ubuntu-cleaner
+# For running UI:
+# xhost +"local:docker@"
+# docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --it -rm gerardpuig/ubuntu-cleaner ubuntu-cleaner
+FROM ubuntu:18.04
+
+ENV USER="user"
+ENV HOME_DIR="/home/${USER}"
+ENV WORK_DIR="${HOME_DIR}/app"
+
+# configure locale
+RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
+    locales \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
+# install minimal system dependencies
+RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
+    make \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# prepare non root env, with sudo access and no password
+RUN useradd --create-home --home-dir ${HOME_DIR} --shell /bin/bash ${USER} \
+    && usermod -append --groups sudo ${USER} \
+    && echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    && mkdir ${WORK_DIR} \
+    && chown ${USER}:${USER} -R ${WORK_DIR}
+
+USER ${USER}
+WORKDIR ${WORK_DIR}
+
+# install app dependencies
+COPY Makefile setup.py ${WORK_DIR}/
+RUN sudo apt update -qq > /dev/null \
+    && sudo make system_dependencies \
+    && make virtualenv \
+    && sudo rm ${WORK_DIR}/Makefile ${WORK_DIR}/setup.py \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+COPY . ${WORK_DIR}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,34 @@
+VIRTUAL_ENV ?= venv
+PIP=$(VIRTUAL_ENV)/bin/pip
+PYTHON=$(VIRTUAL_ENV)/bin/python
+PYTHON_MAJOR_VERSION=2
+PYTHON_MINOR_VERSION=7
+SYSTEM_DEPENDENCIES= \
+    gir1.2-notify-0.7 \
+    libpython$(PYTHON_VERSION)-dev \
+    python$(PYTHON_VERSION) \
+    python$(PYTHON_VERSION)-dev \
+    python-aptdaemon \
+    python-aptdaemon.gtk3widgets \
+    python-gi \
+    virtualenv
+PYTHON_VERSION=$(PYTHON_MAJOR_VERSION).$(PYTHON_MINOR_VERSION)
+PYTHON_MAJOR_MINOR=$(PYTHON_MAJOR_VERSION)$(PYTHON_MINOR_VERSION)
+PYTHON_WITH_VERSION=python$(PYTHON_VERSION)
+DOCKER_IMAGE=gerardpuig/ubuntu-cleaner
+DOCKER_VOLUME=/tmp/.X11-unix:/tmp/.X11-unix
+
+all: virtualenv
+
+system_dependencies:
+	apt install --yes --no-install-recommends $(SYSTEM_DEPENDENCIES)
+
+$(VIRTUAL_ENV):
+	virtualenv --python=$(PYTHON_WITH_VERSION) --system-site-packages $(VIRTUAL_ENV)
+	$(PIP) install lxml
+
+virtualenv: $(VIRTUAL_ENV)
+
 deb:
 	python setup.py --command-packages=stdeb.command sdist_dsc --package ubuntu-cleaner bdist_deb
 
@@ -5,5 +36,17 @@ clean:
 	@rm -rf deb_dist dist ubuntu_cleaner.egg-info
 	@rm -f ubuntu-cleaner*.tar.gz
 
-test:
-	python -m unittest discover tests
+test: virtualenv
+	$(PYTHON) -m unittest discover tests
+
+run: virtualenv
+	$(PYTHON) ubuntu-cleaner
+
+docker/build:
+	docker build --tag=$(DOCKER_IMAGE) .
+
+docker/make/%:
+	docker run -e DISPLAY -v $(DOCKER_VOLUME) --rm $(DOCKER_IMAGE) make $*
+
+docker/shell:
+	docker run -e DISPLAY -v $(DOCKER_VOLUME) -it --rm $(DOCKER_IMAGE)


### PR DESCRIPTION
Makes it easy to run tests from Docker.
```sh
make docker/build
make docker/make/test
```
This will ease continuous integration testing via Travis.
Note that tests can also be ran outside docker via:
```sh
make test
```
The `make docker/make/test` was tested locally and produced the following output.
```
docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --rm gerardpuig/ubuntu-cleaner make test
venv/bin/python -m unittest discover tests

(python -m unittest:6): dbind-WARNING **: 22:14:42.065: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-2iAzGzyNYr: Connection refused
sh: 1: lsb_release: not found
Gtk-Message: 22:14:42.109: Failed to load module "canberra-gtk-module"
[DbusProxy][ERROR] org.freedesktop.DBus.Error.FileNotFound: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory (dbusproxy.py:15)
...
----------------------------------------------------------------------
Ran 3 tests in 0.051s

OK
```
While it produces minor warning (to be solved in subsequent PR), tests are running succesfully.