### PR TITLE
Tests ubuntucleaner.settings.common module

### DIFF
--- a/tests/settings/test_common.py
+++ b/tests/settings/test_common.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+import unittest
+
+from ubuntucleaner.settings.common import RawConfigSetting
+
+config_content = """
+[section1]
+option1=value1
+option2=value2
+"""
+
+
+class TestRawConfigSetting(unittest.TestCase):
+
+    def setUp(self):
+        fp = tempfile.NamedTemporaryFile(delete=False)
+        fp.close()
+        self.config_path = fp.name
+
+    def tearDown(self):
+        os.unlink(self.config_path)
+
+    def test_base(self):
+        fp = open(self.config_path, 'w')
+        fp.write(config_content)
+        fp.close()
+        settings = RawConfigSetting(self.config_path)
+        self.assertEqual(settings.sections(), ['section1'])
+        self.assertEqual(settings.options('section1'), ['option1', 'option2'])
+        self.assertEqual(settings.get_value('section1', 'option1'), 'value1')
+
+    def test_set_value(self):
+        settings = RawConfigSetting(self.config_path)
+        settings.set_value('section2', 'option1', 'value1')
+        self.assertEqual(settings.get_value('section2', 'option1'), 'value1')


### PR DESCRIPTION
Note we're far from 100% coverage because most of the code of this
module isn't actually used. For instance `RawConfigSetting` constructor
with `type` parameter is never used and could probably dropped in the
future. Same goes with the `Schema` class which doesn't seem to be used
at all.